### PR TITLE
IOS-2114 Base Language

### DIFF
--- a/Sources/LingoHubCLI/LingoHubCLI.swift
+++ b/Sources/LingoHubCLI/LingoHubCLI.swift
@@ -249,23 +249,6 @@ open class LingoHubCLI: NSObject, URLSessionDelegate, URLSessionDataDelegate {
     guard stringsDict.count > 0 else {
       return
     }
-//    var i = 0
-//    while i < sourceLocalizations.count {
-//      let localization = sourceLocalizations[i]
-//      i += 1
-//      // In case of <> detection we line
-//      if localization.range(of: #"<.+>"#, options: .regularExpression) != nil {
-//        // If next line after ignored one is empty we jump over it
-//        if i < sourceLocalizations.count {
-//          let nextLine = sourceLocalizations[i]
-//          if nextLine.count == 0 {
-//            i += 1
-//          }
-//        }
-//        continue
-//      }
-//      cleanedLocalizations.append(localization)
-//    }
     
     let filteredStringsDict = stringsDict.filter { (key, value) -> Bool in
         return !(key.first == "<" && key.last == ">") && !(value.first == "<" && value.last == ">")

--- a/Sources/LingoHubCLI/Providers/iOS.swift
+++ b/Sources/LingoHubCLI/Providers/iOS.swift
@@ -75,10 +75,6 @@ open class iOS: ResourceProvider {
       downloadUrl += "?auth_token=" + self.config.token
 
       let locale: String = resource.locale
-      // We do not download the base locale.
-      guard locale != self.config.baseLocale else {
-        continue
-      }
 
       // Removing locale from the resource name
       // Localizable.de.strings -> Localizable.strings


### PR DESCRIPTION
I could not find a reason why we block the download of the base language. Nothing breaks when we enable it, and our lingohub users can edit the english text directly in lingohub in my tests.

I also refactored the placeholder removal code (NSDictionary can read .string files), with the new code all <> disappear from lingohub.